### PR TITLE
Prevent segfault on uninitialized thread

### DIFF
--- a/fileparser_plugin.c
+++ b/fileparser_plugin.c
@@ -213,9 +213,12 @@ static int32_t init()
  */
 static void fini()
 {
-    logging_enabled = 0;
-    pthread_join(logging_thread, NULL);
-    pthread_mutex_destroy(&logging_mutex);
+    if (logging_thread)
+    {
+        logging_enabled = 0;
+        pthread_join(logging_thread, NULL);
+        pthread_mutex_destroy(&logging_mutex);
+    }
 
     /*  cleanup, i.e. use destroy and free */
     if (NULL != fileParamsVector)


### PR DESCRIPTION
This is a quick-and-dirty fix to prevent segmentation faults caused by
`pthread_join` on uninitialized threads when run on more than one process per
node. This solves #12 .

I just test if the thread is initialized and skip the `pthread_join` if not.
While not being sure if this is the "clean-way", this solution is tested and
works with mutltiple tasks per node.